### PR TITLE
Add quit & update to beta 25

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "2.0.0-beta.23",
+	"geode": "2.0.0-beta.25",
 	"gd": "2.204",
 	"version": "v1.0.2",
 	"id": "xiyxs.confirmpracticerestart",
@@ -16,6 +16,12 @@
 		"practice": {
 			"name": "Enable Practice Menu",
 			"description": "Enables the confirm practice menu.",
+			"type": "bool",
+			"default": true
+		},
+		"quit": {
+			"name": "Enable Quit Menu",
+			"description": "Enables the confirm quit menu.",
 			"type": "bool",
 			"default": true
 		},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@ class $modify(PauseLayer) {
 	bool r = false;
 	bool o = false;
 
+	
 	// Practice
 	void onPracticeMode(CCObject* sender) {
 		if (PlayLayer::get()->m_isPracticeMode || m_fields->r || Mod::get()->getSettingValue<bool>("practice") == false || Mod::get()->getSettingValue<bool>("enable") == false) {
@@ -31,7 +32,29 @@ class $modify(PauseLayer) {
 			);
 		}
 	} 
-
+// Quit
+		void onQuit(CCObject* sender) {
+		if (m_fields->r || Mod::get()->getSettingValue<bool>("quit") == false || Mod::get()->getSettingValue<bool>("enable") == false) {
+            PauseLayer::onQuit(sender);
+            return;
+        }
+		if (!o) {
+			o = true;
+			geode::createQuickPopup(
+				"Quit",
+				"Are you sure you want to <cr>quit</c>?",
+				"Cancel", "Quit",
+				[this, sender](auto, bool btn2) {
+					o = false;
+					if (btn2) {
+						this->m_fields->r = true;
+						this->onQuit(sender);
+						this->m_fields->r = false;
+					}
+				}
+			);
+		}
+	} 
 	// Restart
 		void onRestart(CCObject* sender) {
 		if (m_fields->r || Mod::get()->getSettingValue<bool>("restart") == false || Mod::get()->getSettingValue<bool>("enable") == false) {


### PR DESCRIPTION
adds a confirmation menu for quitting a level and updates the geode version to beta 25